### PR TITLE
TP-Link C60v2 support (MAC address source), minor assorted fixes

### DIFF
--- a/files/get_mac_address.sh
+++ b/files/get_mac_address.sh
@@ -1,13 +1,20 @@
 #!/bin/sh
-mac_address=`ifconfig |grep 'br-lan '|sed s/[\ ]/'\n'/g|sed -e s/://g|egrep '^[0-9A-Fa-f]{12}'|tr A-Z a-z` 
-if [ "$mac_address" == "" ] ; then
-  mac_address=`ifconfig |grep 'eth0 '|sed s/[\ ]/'\n'/g|sed -e s/://g|egrep '^[0-9A-Fa-f]{12}'|tr A-Z a-z`
+mac_address=$(ifconfig | grep 'br-lan ' | sed s/[\ ]/'\n'/g | sed -e s/://g | grep -E '^[0-9A-Fa-f]{12}'|tr A-Z a-z )
+if [ -z "$mac_address" ] ; then
+	mac_address=$(ifconfig | grep 'eth0 ' | sed s/[\ ]/'\n'/g | sed -e s/://g | grep -E '^[0-9A-Fa-f]{12}'|tr A-Z a-z)
 fi
+
+#
+# Acerta MAC Address para certos modelos
+#
 model=$(/usr/bin/get_model.sh)
-#
-# Acerta MAC Address para modelo TP-LINKTL-WR741NDv4
-#
-if [ "$model" = "TP-LINKTL-WR741NDv4" ] ; then
-  mac_address=$(cat /sys/devices/platform/ar933x_wmac/ieee80211/phy0/macaddress)
-fi
-echo $mac_address|sed -e s/://g|tr A-Z a-z
+case "$model" in
+	TP-LINK*TL-WR741NDv4)
+		mac_address=$(cat /sys/devices/platform/ar933x_wmac/ieee80211/phy0/macaddress)
+		;;
+	TP-LINK*Archer_C60_v2*)
+		mac_address=$(cat /sys/devices/platform/qca956x_wmac/ieee80211/phy1/macaddress)
+		;;
+esac
+
+echo "$mac_address" | sed -e 's/://g' | tr 'A-Z' 'a-z'

--- a/files/run_simet.sh
+++ b/files/run_simet.sh
@@ -5,9 +5,13 @@ hash_measure_v6=$(/usr/bin/simet_hash_measure -s $cf_host)
 ntpq_enable=$(uci get simet_cron.simet_ntpq.enable)
 if [ "$ntpq_enable" == "true" ] ; then
   /usr/bin/simet_ntpq
-fi                                         
-/usr/bin/simet_geolocation.sh $hash_measure_v4
-/usr/bin/simet_client -4 -m $hash_measure_v4  
-sleep 5                                  
-/usr/bin/simet_geolocation.sh $hash_measure_v6
-/usr/bin/simet_client -6 -m $hash_measure_v6
+fi
+if test -n "$hash_measure_v4" ; then
+	/usr/bin/simet_geolocation.sh $hash_measure_v4
+	/usr/bin/simet_client -4 -m $hash_measure_v4
+	sleep 5
+fi
+if test -n "$hash_measure_v6" ; then
+	/usr/bin/simet_geolocation.sh $hash_measure_v6
+	/usr/bin/simet_client -6 -m $hash_measure_v6
+fi


### PR DESCRIPTION
* Use the correct MAC address (the one printed in the label) for TP-Link Archer C60v2
* Do not attempt to test without a measure-id (i.e. when we fail to contact the SIMET server farm)
