### PR TITLE
[MDC-69] simetbox_register: sleep a minute between tries

### DIFF
--- a/files/simetbox_register.sh
+++ b/files/simetbox_register.sh
@@ -31,6 +31,6 @@ do
     # geolocalização de registro da caixa
     simet_geolocation.sh
   else
-    sleep 10
+    sleep 60
   fi
 done


### PR DESCRIPTION
Sleeping only 10s between failed attempts to register is causing nasty
issues on low-RAM boxes, and it hammers the webservice needlessly as
well.

Sleep one minute between failed attempts.