### PR TITLE
[MDC-175] base: get_mac_address.sh: fix for TL-WDR3600/4300

### DIFF
--- a/files/get_mac_address.sh
+++ b/files/get_mac_address.sh
@@ -12,7 +12,7 @@ case "$model" in
 	TP-LINK*TL-WR740ND|TP-LINK*TL-WR741N*V4|TP-LINK*TL-WR841N*V7|TP-LINK*TL-WR842N*V1)
 		mac_address=$(cat /sys/devices/pci0000:00/0000:00:00.0/ieee80211/phy0/macaddress)
 		;;
-	TP-LINK*TL-WDR3600/4300/4310)
+	TP-LINK*TL-WDR3600_V1|TP-LINK*TL-WDR4300_V1)
 		mac_address=$(cat /sys/devices/pci0000:00/0000:00:00.0/ieee80211/phy1/macaddress)
 		;;
 	*)


### PR DESCRIPTION
Unfortunately, the model string was incorrect, which resulted
in TP-Link TL-WDR3600 and TL-WDR4300 using the br-lan MAC incorrectly,
instead of wlan MAC.

The incorrect MAC used will be MAC-2 in both cases.

This won't cause many issues, unless it is factory-reset or a first
install, in which case the default passwords will be MAC-2.  However,
they are shown in the web interface so user impact is minimal.