### PR TITLE
[MDC-401] base: change simet_geolocation.sh API

### DIFF
--- a/files/run_simet.sh
+++ b/files/run_simet.sh
@@ -7,11 +7,11 @@ if [ "$ntpq_enable" == "true" ] ; then
   /usr/bin/simet_ntpq
 fi
 if test -n "$hash_measure_v4" ; then
-	/usr/bin/simet_geolocation.sh $hash_measure_v4
+	/usr/bin/simet_geolocation.sh $hash_measure_v4 >/dev/null || true
 	/usr/bin/simet_client -4 -m $hash_measure_v4
 	sleep 5
 fi
 if test -n "$hash_measure_v6" ; then
-	/usr/bin/simet_geolocation.sh $hash_measure_v6
+	/usr/bin/simet_geolocation.sh $hash_measure_v6 >/dev/null || true
 	/usr/bin/simet_client -6 -m $hash_measure_v6
 fi

--- a/files/simetbox_register.sh
+++ b/files/simetbox_register.sh
@@ -29,7 +29,7 @@ do
     echo "${hash_device}" > /etc/config/simetbox_hash_configured
     sleep 2
     # geolocalização de registro da caixa
-    simet_geolocation.sh
+    simet_geolocation.sh >/dev/null || true
   else
     sleep 60
   fi


### PR DESCRIPTION
* Output to stdout the geolocation result as per simet-ma API 1
* Return non-zero status when measurement is invalid
* Ignore non-zero status on the scripts that use simet_geolocation.sh,
  since we don't want to abort them when we fail to geolocate.