### PR TITLE
[MDC-421] SIMET-2 enablement

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # initial information about the project
 AC_PREREQ([2.63])
-AC_INIT([simet-tools],[1],[michel@nic.br])
+AC_INIT([simet-tools],[100][medicoes@simet.nic.br])
 AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS([src/config.h])
 

--- a/files/crontab_writer.lua
+++ b/files/crontab_writer.lua
@@ -112,7 +112,8 @@ function generate_crontab()
           service_down = { command =  "sendifupdown.sh" },                                                      
           simet_alexa = { command = "simet_alexa" },                         
           simet_send_if_traffic = { command = "simet_send_if_traffic.sh" },
-          simet_test = { command = "run_simet.sh"}
+          simet_test = { command = "run_simet.sh"},
+          simet_measure = { command = "simet-ma_run.sh --config /usr/lib/simet/simet-ma.conf --config /etc/simet/simet-ma.conf" }
         }                                                                                                         
                                                                                                                           
         local config_table = {}                                                                                           

--- a/files/simet_cron
+++ b/files/simet_cron
@@ -32,3 +32,6 @@ config 'simet_port25' 'simet_port25'
 
 config 'simet_send_if_traffic' 'simet_send_if_traffic'
 	option 'time_step' '20'
+
+config 'simet_measure' 'simet_measure'
+	option 'time_step' '60'

--- a/files/uci-defaults/99-simet-cron
+++ b/files/uci-defaults/99-simet-cron
@@ -78,6 +78,11 @@ write_new_default_values()
 		uci -c /tmp/config set simet_cron.simet_send_if_traffic.enable=true
 	fi
 
+	#### SIMET MA
+	uci -c /tmp/config set simet_cron.simet_measure=simet_measure
+	uci -c /tmp/config set simet_cron.simet_measure.time_step=60
+	uci -c /tmp/config set simet_cron.simet_measure.enable=true
+
 	uci -c /tmp/config commit simet_cron
 }
 


### PR DESCRIPTION
* Hook the new SIMET engine to crontab for now.  It will have its own scheduler in the future, though.